### PR TITLE
isKde was returning wrong flag when called for the first time

### DIFF
--- a/src/dorkbox/util/OSUtil.java
+++ b/src/dorkbox/util/OSUtil.java
@@ -857,7 +857,7 @@ class OSUtil {
                 return isKDE;
             } else if ("kde".equalsIgnoreCase(XDG)) {
                 isKDE = true;
-                return false;
+                return isKDE;
             }
 
             isKDE = false;


### PR DESCRIPTION
When calling isKde method for the first time, the method returned false (while it should be true)