### PR TITLE
isKDE was returning wrong flag on the first method call

### DIFF
--- a/src/dorkbox/util/OSUtil.java
+++ b/src/dorkbox/util/OSUtil.java
@@ -857,7 +857,7 @@ class OSUtil {
                 return isKDE;
             } else if ("kde".equalsIgnoreCase(XDG)) {
                 isKDE = true;
-                return false;
+                return isKDE;
             }
 
             isKDE = false;


### PR DESCRIPTION
On KDE environment, isKDE utility method returned wrong flag when executed for the first time